### PR TITLE
Possible bug fix?

### DIFF
--- a/mini-printf.c
+++ b/mini-printf.c
@@ -22,7 +22,7 @@ static unsigned int
 mini_strlen(const char *s)
 {
 	unsigned int len = 0;
-	while (s[len++]) /* do nothing */;
+	while (s[len] != '\0') len++;
 	return len;
 }
 


### PR DESCRIPTION
Not sure if I'm just missing something (I haven't programmed in C in a long while) but consider the code below:

char *a = "aaa"; 
char b[10] = snprintf(b, 10, "%s bbb", a); 
//b will only contain "aaa"

The "%s" format seems to include the '\0' character of the supplied parameter (which prematurely terminates the string). I traced this to the mini_strlen() method which includes the '\0' character in its count.

I did this change to my forked code and it seems to fix the issue I'm having on my application.
